### PR TITLE
Integrate real meeting data with OpenRouter for follow-up

### DIFF
--- a/server/chatWithOpenrouter.js
+++ b/server/chatWithOpenrouter.js
@@ -5,7 +5,7 @@ dotenv.config();
 
 // Set up OpenAI client with OpenRouter endpoint
 const openai = new OpenAI({
-  apiKey: process.env.OPENROUTER_API_KEY,
+  apiKey: process.env.OPENROUTER_API_KEY || "dummy-key-for-testing",
   baseURL: "https://openrouter.ai/api/v1",
 });
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "rtms-sample",
+  "name": "ai-meeting-copilot-server",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "rtms-sample",
+      "name": "ai-meeting-copilot-server",
       "version": "1.0.0",
       "dependencies": {
         "@langchain/core": "^0.3.57",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -304,16 +304,8 @@ function App() {
     setShowFollowUp(true);
   };
 
-  // Mock meeting data for the follow-up component
-  const mockMeetingData = {
-    id: "meeting-123",
-    title: "Team Sync Meeting",
-    date: new Date(),
-    participants: ["john@example.com", "jane@example.com", "bob@example.com"],
-    transcripts: transcripts,
-    screenshots: screenshots,
-    summary: "Meeting summary will be generated..."
-  };
+  // Meeting ID for the follow-up component (using 'current' as default)
+  const currentMeetingId = "current";
 
   // dark mode 切换
   const [isDark, setIsDark] = useState(() => {
@@ -349,7 +341,7 @@ function App() {
       </div>
       {showFollowUp ? (
         <PostMeetingFollowUp 
-          meetingData={mockMeetingData}
+          meetingId={currentMeetingId}
           onClose={() => setShowFollowUp(false)}
         />
       ) : (


### PR DESCRIPTION
Replace mock data in PostMeetingFollowUp with AI-generated insights from server-fetched transcripts.

The PostMeetingFollowUp component now fetches real meeting transcripts and screenshots from new server endpoints. These transcripts are then sent to OpenRouter via a new API to generate a meeting name, topic, summary, next steps, and key points, which are displayed in the UI.

---

[Open in Web](https://www.cursor.com/agents%3Fid=bc-91763662-6608-4fe8-a8a5-5491439197a6) • [Open in Cursor](https://cursor.com/background-agent%3FbcId=bc-91763662-6608-4fe8-a8a5-5491439197a6)